### PR TITLE
Move doctrine/orm to require-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,25 @@ jobs:
       - name: Run Psalm
         run: vendor/bin/psalm --show-info=false --find-unused-psalm-suppress --no-progress
 
+  deps:
+    name: Check dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run composer-dependency-analyser
+        run: composer dump -a && vendor/bin/composer-dependency-analyser
+
   phpunit:
     name: PHPUnit
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "require": {
         "brick/date-time": "~0.6.0",
         "doctrine/dbal": "^2.7.0 || ^3.0",
-        "doctrine/orm": "^2.7.0",
         "php": "^8.1"
     },
     "require-dev": {
@@ -21,7 +20,9 @@
         "php-coveralls/php-coveralls": "^2.4",
         "vimeo/psalm": "5.17.0",
         "doctrine/annotations": "^1.0",
-        "guzzlehttp/guzzle": "^7.0"
+        "doctrine/orm": "^2.7.0",
+        "guzzlehttp/guzzle": "^7.0",
+        "shipmonk/composer-dependency-analyser": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi, I used your repository to test our [composer-dependency-analyser](https://github.com/shipmonk-rnd/composer-dependency-analyser) and I believe it found one issue:

- There is not a single usage of any symbol from `doctrine/orm` in `src` so I believe it should not be listed in `require`.
   - So I moved it to `require-dev`
- I also added this tool to CI so that such problem never happens again