### PR TITLE
Add name const to Types

### DIFF
--- a/src/Types/DayOfWeekType.php
+++ b/src/Types/DayOfWeekType.php
@@ -20,6 +20,8 @@ use ValueError;
  */
 final class DayOfWeekType extends Type
 {
+    public const NAME = 'DayOfWeek';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/src/Types/DurationType.php
+++ b/src/Types/DurationType.php
@@ -19,6 +19,8 @@ use Override;
  */
 final class DurationType extends Type
 {
+    public const NAME = 'Duration';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/src/Types/InstantType.php
+++ b/src/Types/InstantType.php
@@ -18,6 +18,8 @@ use Override;
  */
 final class InstantType extends Type
 {
+    public const NAME = 'Instant';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/src/Types/LocalDateTimeType.php
+++ b/src/Types/LocalDateTimeType.php
@@ -21,6 +21,8 @@ use function str_replace;
  */
 final class LocalDateTimeType extends Type
 {
+    public const NAME = 'LocalDateTime';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/src/Types/LocalDateType.php
+++ b/src/Types/LocalDateType.php
@@ -19,6 +19,8 @@ use Override;
  */
 final class LocalDateType extends Type
 {
+    public const NAME = 'LocalDate';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/src/Types/LocalTimeType.php
+++ b/src/Types/LocalTimeType.php
@@ -19,6 +19,8 @@ use Override;
  */
 final class LocalTimeType extends Type
 {
+    public const NAME = 'LocalTime';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/src/Types/PeriodType.php
+++ b/src/Types/PeriodType.php
@@ -19,6 +19,8 @@ use Override;
  */
 final class PeriodType extends Type
 {
+    public const NAME = 'Period';
+
     #[Override]
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {

--- a/tests/Types/DayOfWeekTypeTest.php
+++ b/tests/Types/DayOfWeekTypeTest.php
@@ -110,6 +110,6 @@ class DayOfWeekTypeTest extends TestCase
 
     private function getDayOfWeekType(): DayOfWeekType
     {
-        return Type::getType('DayOfWeek');
+        return Type::getType(DayOfWeekType::NAME);
     }
 }

--- a/tests/Types/DurationTypeTest.php
+++ b/tests/Types/DurationTypeTest.php
@@ -99,6 +99,6 @@ class DurationTypeTest extends TestCase
 
     private function getDurationType(): DurationType
     {
-        return Type::getType('Duration');
+        return Type::getType(DurationType::NAME);
     }
 }

--- a/tests/Types/InstantTypeTest.php
+++ b/tests/Types/InstantTypeTest.php
@@ -83,6 +83,6 @@ class InstantTypeTest extends TestCase
 
     private function getInstantType(): InstantType
     {
-        return Type::getType('Instant');
+        return Type::getType(InstantType::NAME);
     }
 }

--- a/tests/Types/LocalDateTimeTypeTest.php
+++ b/tests/Types/LocalDateTimeTypeTest.php
@@ -107,6 +107,6 @@ class LocalDateTimeTypeTest extends TestCase
 
     private function getLocalDateTimeType(): LocalDateTimeType
     {
-        return Type::getType('LocalDateTime');
+        return Type::getType(LocalDateTimeType::NAME);
     }
 }

--- a/tests/Types/LocalDateTypeTest.php
+++ b/tests/Types/LocalDateTypeTest.php
@@ -99,6 +99,6 @@ class LocalDateTypeTest extends TestCase
 
     private function getLocalDateType(): LocalDateType
     {
-        return Type::getType('LocalDate');
+        return Type::getType(LocalDateType::NAME);
     }
 }

--- a/tests/Types/LocalTimeTypeTest.php
+++ b/tests/Types/LocalTimeTypeTest.php
@@ -103,6 +103,6 @@ class LocalTimeTypeTest extends TestCase
 
     private function getLocalTimeType(): LocalTimeType
     {
-        return Type::getType('LocalTime');
+        return Type::getType(LocalTimeType::NAME);
     }
 }

--- a/tests/Types/PeriodTypeTest.php
+++ b/tests/Types/PeriodTypeTest.php
@@ -99,6 +99,6 @@ class PeriodTypeTest extends TestCase
 
     private function getPeriodType(): PeriodType
     {
-        return Type::getType('Period');
+        return Type::getType(PeriodType::NAME);
     }
 }


### PR DESCRIPTION
This pull request introduces a consistent naming convention for custom type classes and updates their usage throughout the codebase. The main change is the addition of a `NAME` constant to each custom type class, which is then used in place of hardcoded strings in test files. This enhances maintainability and reduces the risk of errors due to typos.

Naming convention improvements:

* Added a `NAME` constant to each custom type class (`DayOfWeekType`, `DurationType`, `InstantType`, `LocalDateTimeType`, `LocalDateType`, `LocalTimeType`, `PeriodType`) to standardize type name references. [[1]](diffhunk://#diff-933dc80e4ff3cf7b36391720a5cb1245b7af5e70d3fd3535c0dbaa0fb7e14615R23-R24) [[2]](diffhunk://#diff-5aa7556c7a2502b9fe0191eb64cd40238eb51f45528018852bcf88eb02610a1fR22-R23) [[3]](diffhunk://#diff-2236f31366c6307bef34a637cb14a6f17e29973c62d982a2d0bf0d46bdd9f504R21-R22) [[4]](diffhunk://#diff-989e8c593acce80f09883daedf685c43441614060874702d4af1d614dc25ceadR24-R25) [[5]](diffhunk://#diff-160bb798db22e541b468e183e6fb3fb1976e06aed0cc47b3dffa544986943ef8R22-R23) [[6]](diffhunk://#diff-60423bf60467bd9b8cebc31fcc4e0f4cb05d047f959a63a23f61ef66e09073edR22-R23) [[7]](diffhunk://#diff-fa1bb114d0e8c7bbc7c5193f0e16954a6afedda4284b249f9a7f7ed1d53d2b83R22-R23)

Test code updates:

* Updated test files to use the new `NAME` constant instead of hardcoded strings when retrieving types, improving reliability and consistency. (`DayOfWeekTypeTest.php`, `DurationTypeTest.php`, `InstantTypeTest.php`, `LocalDateTimeTypeTest.php`, `LocalDateTypeTest.php`, `LocalTimeTypeTest.php`, `PeriodTypeTest.php`) [[1]](diffhunk://#diff-2863004be97a1e3c7614d257f710821927827a4b78f28ea4fb04893c847878a8L113-R113) [[2]](diffhunk://#diff-f4a237a852c7f59630a60a6445d808027936b7a0514b90fdcc501b86f5ffa317L102-R102) [[3]](diffhunk://#diff-4e81569e22d13e06c7cfb7350c23bc168d1241133a3240e050cc6842f90bbd6aL86-R86) [[4]](diffhunk://#diff-b29f37ae281ce7d9bd056a43a0c81b6e0af9d1d185e7e48da43dcc9d85053bafL110-R110) [[5]](diffhunk://#diff-f9f6279dec1855bd071e5b8b22341570ad2893d1b8d5c242bf056a0083a40798L102-R102) [[6]](diffhunk://#diff-5b9c9999e3dbff7ee79e24cc39362669bd0ac3469e97b0e0785d4c48c6669b66L106-R106) [[7]](diffhunk://#diff-8334b3a6c6b6a2e8826f0d582c5b2a2a976db95fcc93f36a0180fd8f78eefe39L102-R102)

Inspired by:
- https://www.doctrine-project.org/projects/doctrine-orm/en/3.6/cookbook/custom-mapping-types.html
- https://github.com/ramsey/uuid-doctrine/blob/main/src/UuidType.php 